### PR TITLE
Fix rpy2 >= 3.6 compatibility in optimize/relax and check_hemisphering

### DIFF
--- a/PyRacmacs/optimization.py
+++ b/PyRacmacs/optimization.py
@@ -78,9 +78,9 @@ def make_map_from_table(
         assert titer_weights.shape==titer_table.shape,\
           "titer_table and titer_weights must have the same shape"
 
-        ro.numpy2ri.activate()
-        titer_weights = ro.r.matrix(titer_weights, nrow=titer_weights.shape[0],
-                                    ncol=titer_weights.shape[1])
+        with ro.conversion.localconverter(ro.default_converter + ro.numpy2ri.converter):
+            titer_weights = ro.r.matrix(titer_weights, nrow=titer_weights.shape[0],
+                                        ncol=titer_weights.shape[1])
 
 
     if isinstance(options,dict):
@@ -131,9 +131,9 @@ def optimize_map(racmap, number_of_dimensions: int=2,
         assert titer_weights.shape==racmap.shape,\
           "titer_table and titer_weights must have the same shape"
 
-        ro.numpy2ri.activate()
-        titer_weights = ro.r.matrix(titer_weights, nrow=titer_weights.shape[0],
-                                    ncol=titer_weights.shape[1])
+        with ro.conversion.localconverter(ro.default_converter + ro.numpy2ri.converter):
+            titer_weights = ro.r.matrix(titer_weights, nrow=titer_weights.shape[0],
+                                        ncol=titer_weights.shape[1])
 
     if isinstance(options,dict):
         options = RacOptimizerOptions(**options)
@@ -151,7 +151,6 @@ def optimize_map(racmap, number_of_dimensions: int=2,
                                           verbose=verbose,
                                           options=options.options_R
                                           )
-    ro.numpy2ri.deactivate()
     optimized_racmap = RacMap(optimized_map_R)
 
     return optimized_racmap
@@ -166,9 +165,9 @@ def relax_map(acmap, optimization_number: int=0, fixed_antigens: bool=False,
     if titer_weights is None:
         titer_weights = rNULL
     else:
-        ro.numpy2ri.activate()
-        titer_weights = ro.r.matrix(titer_weights, nrow=titer_weights.shape[0],
-                                    ncol=titer_weights.shape[1])
+        with ro.conversion.localconverter(ro.default_converter + ro.numpy2ri.converter):
+            titer_weights = ro.r.matrix(titer_weights, nrow=titer_weights.shape[0],
+                                        ncol=titer_weights.shape[1])
 
     if options is None:
         options = {}
@@ -185,7 +184,6 @@ def relax_map(acmap, optimization_number: int=0, fixed_antigens: bool=False,
                                      fixed_sera=fixed_sera,
                                      titer_weights=titer_weights,
                                      options=options.options_R)
-    ro.numpy2ri.deactivate()
 
     relaxed_map = RacMap(relaxed_map_R)
 

--- a/PyRacmacs/utils/conversion.py
+++ b/PyRacmacs/utils/conversion.py
@@ -9,6 +9,7 @@ Created on Wed Feb 23 21:40:57 2022
 import numpy as np
 import json
 import rpy2
+import rpy2.rlike.container
 import rpy2.robjects as ro
 
 from rpy2.robjects import r,  conversion, default_converter
@@ -86,22 +87,33 @@ def titers_num_to_str(num_titers, titer_types):
 def odict_to_dict(odict):
 
   '''
-  should be used with odicts which does not contain None keys or
-  other odicts with None keys
+  Recursively converts an rpy2 named container into native Python objects:
+  a dict when every entry is uniquely named, otherwise a list. Leaf values
+  are returned unchanged.
+
+  Handles both the rpy2 >= 3.6 ``NamedList`` and the legacy ``OrdDict``.
   '''
 
-  new_dict = {}
+  NamedList = getattr(rpy2.rlike.container, 'NamedList', None)
+  OrdDict = getattr(rpy2.rlike.container, 'OrdDict', None)
 
-  for key in odict:
+  if NamedList is not None and isinstance(odict, NamedList):
+    names = list(odict.names())
+    values = [odict_to_dict(val) for val in odict]
+    if names and all(n is not None for n in names) and len(set(names)) == len(names):
+      return dict(zip(names, values))
+    return values
 
-    if isinstance(odict[key], rpy2.rlike.container.OrdDict):
+  if OrdDict is not None and isinstance(odict, OrdDict):
+    new_dict = {}
+    for key in odict:
       new_dict[key] = odict_to_dict(odict[key])
-    elif isinstance(odict[key], list):
-      new_dict[key] = [odict_to_dict(val) for val in odict[key]]
-    else:
-      new_dict[key] = odict[key]
+    return new_dict
 
-  return new_dict
+  if isinstance(odict, list):
+    return [odict_to_dict(val) for val in odict]
+
+  return odict
 
 
 def convert_options(option_dict):

--- a/PyRacmacs/validation.py
+++ b/PyRacmacs/validation.py
@@ -318,17 +318,15 @@ def check_hemisphering(racmap, optimization_number=0, grid_spacing=0.25,
     result = ro.conversion.get_conversion().rpy2py(result_R)
 
 
-  ag_diagnostics=\
-    list(result["optimizations"].items())[optimization_number][1]["ag_diagnostics"]
+  optimization = result.getbyname("optimizations")[optimization_number]
 
   ag_names = racmap.ag_names
   sr_names = racmap.sr_names
 
-  ag_diagnostics = {ag:odict_to_dict(val[1]) for ag,val in zip(ag_names, ag_diagnostics.items())}
+  ag_diagnostics = odict_to_dict(optimization.getbyname("ag_diagnostics"))
+  sr_diagnostics = odict_to_dict(optimization.getbyname("sr_diagnostics"))
 
-  sr_diagnostics=\
-    list(result["optimizations"].items())[optimization_number][1]["sr_diagnostics"]
-
-  sr_diagnostics = {sr:odict_to_dict(val[1]) for sr,val in zip(sr_names, sr_diagnostics.items())}
+  ag_diagnostics = {ag:diag for ag,diag in zip(ag_names, ag_diagnostics)}
+  sr_diagnostics = {sr:diag for sr,diag in zip(sr_names, sr_diagnostics)}
 
   return sr_diagnostics, ag_diagnostics


### PR DESCRIPTION
rpy2 3.6 turns the deprecated numpy2ri.activate()/deactivate() calls into hard errors and replaces the OrdDict container with NamedList, which does not support string-key indexing. This broke optimize_map, relax_map and check_hemisphering against current rpy2.

- optimization.py: replace numpy2ri.activate()/deactivate() with the localconverter context already used elsewhere; drop the unconditional deactivate() calls that fired on every optimize_map/relax_map call.
- utils/conversion.py: rewrite odict_to_dict as a recursive converter that handles NamedList (named -> dict, unnamed -> list) and the legacy OrdDict.
- validation.py: access checkHemisphering results via the NamedList API (getbyname + integer indexing) instead of string-indexed .items().

Full test suite passes.